### PR TITLE
Honor zeros

### DIFF
--- a/lib/String/MkPasswd.pm
+++ b/lib/String/MkPasswd.pm
@@ -125,7 +125,7 @@ sub mkpasswd {
 	# If there is any underspecification, use additional letters.
 	my $filler = $length - ($minnum + $minupper + $minspecial + $minlower);
 
-	if ( $filler < 0 ) {
+	if ( $filler < 0 or $filler == $length) {
 		if ( $fatal || $FATAL ) {
 			croak "Impossible to generate $length-character password with "
 					. "$minnum numbers, $minlower lowercase letters, "
@@ -146,9 +146,25 @@ sub mkpasswd {
 	my $rnums = $distribute ? $keys{$ambiguousity}{dist}{rnums} : $keys{$ambiguousity}{undist}{rnums};
 	my $lspec = $distribute ? $keys{$ambiguousity}{dist}{lspec} : $keys{$ambiguousity}{undist}{lspec};
 	my $rspec = $distribute ? $keys{$ambiguousity}{dist}{rspec} : $keys{$ambiguousity}{undist}{rspec};
-	my $lfill = [ @$lkeys, @$lnums, @$lspec ];
-	my $rfill = [ @$rkeys, @$rnums, @$rspec ];
-
+	my $lfill = [];
+	my $rfill = [];
+	if( $minnum > 0 ) {
+	    push(@$lfill, @$lnums);
+	    push(@$rfill, @$rnums);
+	}
+	if( $minspecial > 0 ) {
+	    push(@$lfill, @$lspec);
+	    push(@$rfill, @$rspec);
+	}
+	if( $minlower > 0 ) {
+	    push(@$lfill, @$lkeys);
+	    push(@$rfill, @$rkeys);
+	}
+	if( $minupper > 0 ) {
+	    push(@$lfill, map uc, @$lkeys);
+	    push(@$rfill, map uc, @$rkeys);
+	}
+	
 	# Generate password.
 
 	my @lpass = (undef) x $length;	# password chars typed by left hand

--- a/lib/String/MkPasswd.pm
+++ b/lib/String/MkPasswd.pm
@@ -345,7 +345,8 @@ return C<undef> on error.  The default is false.
 =back
 
 If B<-minnum>, B<-minlower>, B<-minupper>, and B<-minspecial> do not add
-up to B<-length>, B<-minlower> will be increased to compensate.
+up to B<-length>, characters from all clases defined with at least 1
+minimum occurence, will be added to compensate.
 However, if B<-minnum>, B<-minlower>, B<-minupper>, and B<-minspecial>
 add up to more than B<-length>, then C<mkpasswd()> will return C<undef>.
 See the section entitled L</"EXCEPTION HANDLING"> for how to change this

--- a/lib/String/MkPasswd.pm
+++ b/lib/String/MkPasswd.pm
@@ -62,9 +62,6 @@ my %keys = (
 			],
 		},
 		undist => {
-			lkeys	=> [
-				qw(a b c d e f g h i j k l m n o p q r s t u v w x y z)
-			],
 			lkeys => [
 				qw(a b c d e f g h i j k l m n o p q r s t u v w x y z)
 			],
@@ -125,7 +122,10 @@ sub mkpasswd {
 		? $args{"-fatal"}
 		: FATAL;
 
-	if ( $minnum + $minlower + $minupper + $minspecial > $length ) {
+	# If there is any underspecification, use additional letters.
+	my $filler = $length - ($minnum + $minupper + $minspecial + $minlower);
+
+	if ( $filler < 0 ) {
 		if ( $fatal || $FATAL ) {
 			croak "Impossible to generate $length-character password with "
 					. "$minnum numbers, $minlower lowercase letters, "
@@ -135,9 +135,6 @@ sub mkpasswd {
 			return;
 		}
 	}
-
-	# If there is any underspecification, use additional lowercase letters.
-	$minlower = $length - ($minnum + $minupper + $minspecial);
 
 	# Choose left or right starting hand.
 	my $initially_left = my $isleft = int rand 2;
@@ -149,6 +146,8 @@ sub mkpasswd {
 	my $rnums = $distribute ? $keys{$ambiguousity}{dist}{rnums} : $keys{$ambiguousity}{undist}{rnums};
 	my $lspec = $distribute ? $keys{$ambiguousity}{dist}{lspec} : $keys{$ambiguousity}{undist}{lspec};
 	my $rspec = $distribute ? $keys{$ambiguousity}{dist}{rspec} : $keys{$ambiguousity}{undist}{rspec};
+	my $lfill = [ @$lkeys, @$lnums, @$lspec ];
+	my $rfill = [ @$rkeys, @$rnums, @$rspec ];
 
 	# Generate password.
 
@@ -186,6 +185,14 @@ sub mkpasswd {
 	}
 	for ( my $i = 0; $i < $right; $i++ ) {
 		&_insert(\@rpass, $rspec->[rand @$rspec]);
+	}
+
+	($left, $right) = &_psplit($filler, \$isleft);
+	for ( my $i = 0; $i < $left; $i++ ) {
+		&_insert(\@lpass, $lfill->[rand @$lfill]);
+	}
+	for ( my $i = 0; $i < $right; $i++ ) {
+		&_insert(\@rpass, $rfill->[rand @$rfill]);
 	}
 
 	# Merge results together.


### PR DESCRIPTION
Similar to my last pull request, but here you can specify that characters from a certain class may not be used by specifying (e.g.) -minspecial=>0 while in my last pull request, they would have been used to compensate the password length.